### PR TITLE
Update dependency "akamai-open/edgegrid-auth" from "^0.6" to "^0.6.2"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "akamai-open/edgegrid-auth": "^0.6",
+        "akamai-open/edgegrid-auth": "^0.6.2",
         "guzzlehttp/guzzle": "^6.0",
         "psr/log": "^1.0",
         "monolog/monolog": "^1.15",


### PR DESCRIPTION
because `\Akamai\Open\EdgeGrid\Client::createFromEnv()` calls
`\Akamai\Open\EdgeGrid\Authentication::createFromEnv()`