### PR TITLE
Upgraded Monolog to match php 7.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "akamai-open/edgegrid-auth": "^1.0.0",
         "guzzlehttp/guzzle": "^6.1.1",
         "psr/log": "^1.0",
-        "monolog/monolog": "^1.15",
+        "monolog/monolog": ">=1.15",
         "league/climate": "~3.2"
     },
     "require-dev": {


### PR DESCRIPTION
The repository was not installing on more recent versions of php due to the Monolog repository version restrictions. This edit serves my purpose and I thought it might help others as well.