### PR TITLE
Upgraded Monolog to match php 7.3 compatibility & upgrade Guzzle to support ^7.0 (now works in Laravel ^8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ To enable `Debug` call `Client->setInstanceDebug()`, `Client::setDebug()`, or se
 $auth = \Akamai\Open\EdgeGrid\Handler\Authentication::createFromEdgeRcFile();
 // or:
 $auth = new \Akamai\Open\EdgeGrid\Handler\Authentication;
+$auth->setSigner();
 $auth->setAuth($client_token, $client_secret, $access_token);
 
 // Create the handler stack

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     "require": {
         "php": ">=5.5",
         "akamai-open/edgegrid-auth": "^1.0.0",
-        "guzzlehttp/guzzle": "^6.1.1",
+        "guzzlehttp/guzzle": "^6.1.1 || ^7.0",
         "psr/log": "^1.0",
-        "monolog/monolog": "^1.15",
+        "monolog/monolog": ">=1.15",
         "league/climate": "~3.2"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -144,7 +144,7 @@ class Client extends \GuzzleHttp\Client implements \Psr\Log\LoggerAwareInterface
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function sendAsync(\Psr\Http\Message\RequestInterface $request, array $options = [])
+    public function sendAsync(\Psr\Http\Message\RequestInterface $request, array $options = []): GuzzleHttp\Promise\PromiseInterface
     {
         $options = $this->setRequestOptions($options);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -123,7 +123,7 @@ class Client extends \GuzzleHttp\Client implements \Psr\Log\LoggerAwareInterface
      * @return \GuzzleHttp\Promise\PromiseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function requestAsync($method, $uri = null, array $options = [])
+    public function requestAsync($method, $uri = null, array $options = []): \GuzzleHttp\Promise\PromiseInterface
     {
         $options = $this->setRequestOptions($options);
 
@@ -144,7 +144,7 @@ class Client extends \GuzzleHttp\Client implements \Psr\Log\LoggerAwareInterface
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function sendAsync(\Psr\Http\Message\RequestInterface $request, array $options = []): GuzzleHttp\Promise\PromiseInterface
+    public function sendAsync(\Psr\Http\Message\RequestInterface $request, array $options = []): \GuzzleHttp\Promise\PromiseInterface
     {
         $options = $this->setRequestOptions($options);
 


### PR DESCRIPTION
Upgraded Monolog
Upgraded Guzzle

Upgraded readme: without this line, I would get:
`Akamai/Open/EdgeGrid/Exception/HandlerException with message 'Signer not set, make sure to call setSigner first'`