### PR TITLE
Fix php 8.4 deprecations

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -120,7 +120,7 @@ class Client implements \Psr\Log\LoggerAwareInterface, \Psr\Http\Client\ClientIn
      */
     public function __construct(
         $config = [],
-        Authentication $authentication = null
+        ?Authentication $authentication = null
     ) {
         $config = $this->setAuthenticationHandler($config, $authentication);
         $config = $this->setBasicOptions($config);
@@ -355,7 +355,7 @@ class Client implements \Psr\Log\LoggerAwareInterface, \Psr\Http\Client\ClientIn
      * @param \Psr\Log\LoggerInterface $logger
      */
     public function setLogger(
-        \Psr\Log\LoggerInterface $logger = null,
+        ?\Psr\Log\LoggerInterface $logger = null,
         $messageFormat = null
     ): void  {
         if ($logger === null) {
@@ -533,7 +533,7 @@ class Client implements \Psr\Log\LoggerAwareInterface, \Psr\Http\Client\ClientIn
      * @param array $config
      * @param Authentication|null $authentication
      */
-    protected function setAuthentication(array $config, Authentication $authentication = null)
+    protected function setAuthentication(array $config, ?Authentication $authentication = null)
     {
         $this->authentication = $authentication;
         if ($authentication === null) {
@@ -556,7 +556,7 @@ class Client implements \Psr\Log\LoggerAwareInterface, \Psr\Http\Client\ClientIn
      * @param Authentication|null $authentication
      * @return array
      */
-    protected function setAuthenticationHandler(array $config, Authentication $authentication = null)
+    protected function setAuthenticationHandler(array $config, ?Authentication $authentication = null)
     {
         $this->setAuthentication($config, $authentication);
 

--- a/src/Handler/Authentication.php
+++ b/src/Handler/Authentication.php
@@ -49,7 +49,7 @@ class Authentication
      *
      * @param Signer|null $auth
      */
-    public function setSigner(\Akamai\Open\EdgeGrid\Authentication $auth = null)
+    public function setSigner(?\Akamai\Open\EdgeGrid\Authentication $auth = null)
     {
         $this->signer = $auth;
         if ($this->signer === null) {


### PR DESCRIPTION
```
PHP Deprecated: Akamai\Open\EdgeGrid\Client::__construct(): Implicitly marking parameter $authentication as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/akamai-open/edgegrid-client/src/Client.php on line 121
PHP Deprecated: Akamai\Open\EdgeGrid\Client::setLogger(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/akamai-open/edgegrid-client/src/Client.php on line 357
PHP Deprecated: Akamai\Open\EdgeGrid\Client::setAuthentication(): Implicitly marking parameter $authentication as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/akamai-open/edgegrid-client/src/Client.php on line 536
PHP Deprecated: Akamai\Open\EdgeGrid\Client::setAuthenticationHandler(): Implicitly marking parameter $authentication as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/akamai-open/edgegrid-client/src/Client.php on line 559
```